### PR TITLE
Add separate endpoint for edit

### DIFF
--- a/Grimoire.Api/Exceptions/ConfigurationException.cs
+++ b/Grimoire.Api/Exceptions/ConfigurationException.cs
@@ -1,0 +1,5 @@
+﻿namespace Grimoire.Api.Exceptions;
+
+public class ConfigurationException(string message) : Exception(message)
+{
+}

--- a/Grimoire.Api/Exceptions/ConflictException.cs
+++ b/Grimoire.Api/Exceptions/ConflictException.cs
@@ -1,0 +1,5 @@
+﻿namespace Grimoire.Api.Exceptions;
+
+public class ConflictException(string message) : Exception(message)
+{
+}

--- a/Grimoire.Api/Program.cs
+++ b/Grimoire.Api/Program.cs
@@ -1,16 +1,17 @@
-using Amazon.DynamoDBv2.DataModel;
 using Amazon.DynamoDBv2;
-using Grimoire.Api.Repositories;
+using Amazon.DynamoDBv2.DataModel;
+using Grimoire.Api.Exceptions;
 using Grimoire.Api.Models;
-using System.Security.AccessControl;
+using Grimoire.Api.Repositories;
+using Grimoire.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
-
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<IDynamoDBContext, DynamoDBContext>();
 builder.Services.AddSingleton<IAmazonDynamoDB, AmazonDynamoDBClient>();
 builder.Services.AddSingleton<IBookRepository, BookRepository>();
+builder.Services.AddSingleton<IBookService, BookService>();
 
 var app = builder.Build();
 
@@ -22,35 +23,61 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapGet("/book/{isbn}", async (IBookRepository bookRepository, string isbn) =>
+app.MapGet("/book/{isbn}", async (IBookService bookService, string isbn) =>
 {
-    var book = await bookRepository.GetBookByIsbnAsync(isbn);
+    var book = await bookService.GetBookByIsbnAsync(isbn);
     return book is null ? Results.NotFound() : Results.Ok(book);
 })
-.WithName("GetBook")
+.WithName("BookGet")
 .WithOpenApi();
 
-app.MapGet("/books", async (IBookRepository bookRepository, int count, string? lastEvaluatedKey) =>
+app.MapGet("/books", async (IBookService bookService, int? count, string? lastEvaluatedKey) =>
 {
-    return await bookRepository.GetBooksAsync(count, lastEvaluatedKey);
+    return await bookService.GetBooksAsync(count, lastEvaluatedKey);
 })
-.WithName("GetBooks")
+.WithName("BooksGet")
 .WithOpenApi();
 
-app.MapPost("/save/book", async (IBookRepository bookRepository, Book book) =>
+app.MapPost("/book/add", async (IBookService bookService, Book book) =>
 {
-    await bookRepository.SaveBookAsync(book);
-    return Results.Created($"/book/{book.Isbn}", book);
+    Book createdBook;
+    try
+    {
+        createdBook = await bookService.AddBookAsync(book);
+    }
+    catch (ConflictException exception)
+    {
+        return Results.Conflict(exception);
+    }
+
+    return Results.Created($"/book/{book.Isbn}", createdBook);
 })
-.WithName("SaveBook")
+.WithName("BookSave")
 .WithOpenApi();
 
-app.MapDelete("/delete/book/{isbn}", async (IBookRepository bookRepository, string isbn) =>
+app.MapDelete("/book/delete/{isbn}", async (IBookService bookService, string isbn) =>
 {
-    await bookRepository.DeleteBookAsync(isbn);
+    await bookService.DeleteBookAsync(isbn);
     return Results.NoContent();
 })
 .WithName("DeleteBook")
+.WithOpenApi();
+
+app.MapPut("/book/edit", async (IBookService bookService, Book book) =>
+{
+    Book editedBook;
+    try
+    {
+        editedBook = await bookService.EditBookAsync(book);
+    }
+    catch (ConflictException exception)
+    {
+        return Results.Conflict(exception);
+    }
+
+    return Results.Ok(editedBook);
+})
+.WithName("BookEdit")
 .WithOpenApi();
 
 app.Run();

--- a/Grimoire.Api/Services/BookService.cs
+++ b/Grimoire.Api/Services/BookService.cs
@@ -1,0 +1,70 @@
+﻿using Grimoire.Api.Exceptions;
+using Grimoire.Api.Models;
+using Grimoire.Api.Repositories;
+
+namespace Grimoire.Api.Services;
+
+public class BookService : IBookService
+{
+    private readonly int defaultPageSize;
+    private readonly int maxPageSize;
+    private readonly IBookRepository bookRepository;
+
+    public BookService(IConfiguration configuration, IBookRepository bookRepository)
+    {
+        this.bookRepository = bookRepository;
+        defaultPageSize = configuration.GetValue<int>("Application:Pagination:DefaultPageSize");
+        maxPageSize = configuration.GetValue<int>("Application:Pagination:MaxPageSize");
+        if (defaultPageSize <= 0)
+        {
+            throw new ConfigurationException("Default page size must be greater than 0");
+        }
+
+        if (maxPageSize <= 0)
+        {
+            throw new ConfigurationException("Max page size must be greater than 0");
+        }
+    }
+
+    public async Task<Book> AddBookAsync(Book book)
+    {
+        var existingBook = await bookRepository.GetBookByIsbnAsync(book.Isbn);
+        if (existingBook is not null)
+        {
+            throw new ConflictException("There is already a book with the given ISBN.");
+        }
+
+        return book;
+    }
+
+    public Task DeleteBookAsync(string isbn) => bookRepository.DeleteBookAsync(isbn);
+
+    public async Task<Book> EditBookAsync(Book book)
+    {
+        var existingBook = await bookRepository.GetBookByIsbnAsync(book.Isbn);
+        if (existingBook is null)
+        {
+            throw new ConflictException("There is no book with the given ISBN.");
+        }
+
+        await bookRepository.SaveBookAsync(book);
+        return book;
+    }
+
+    public Task<Book> GetBookByIsbnAsync(string isbn) => bookRepository.GetBookByIsbnAsync(isbn);
+
+    public Task<PagedResults<Book>> GetBooksAsync(int? count, string? lastEvaluatedKey)
+    {
+        if (count is null || count <= 0)
+        {
+            count = defaultPageSize;
+        }
+
+        if (count > maxPageSize)
+        {
+            count = maxPageSize;
+        }
+
+        return bookRepository.GetBooksAsync(count.Value, lastEvaluatedKey);
+    }
+}

--- a/Grimoire.Api/Services/IBookService.cs
+++ b/Grimoire.Api/Services/IBookService.cs
@@ -1,0 +1,16 @@
+﻿using Grimoire.Api.Models;
+
+namespace Grimoire.Api.Services;
+
+public interface IBookService
+{
+    public Task<Book> AddBookAsync(Book book);
+
+    public Task<PagedResults<Book>> GetBooksAsync(int? count, string? lastEvaluatedKey);
+
+    public Task<Book> GetBookByIsbnAsync(string isbn);
+
+    public Task DeleteBookAsync(string isbn);
+
+    public Task<Book> EditBookAsync(Book book);
+}

--- a/Grimoire.Api/appsettings.json
+++ b/Grimoire.Api/appsettings.json
@@ -5,5 +5,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Application": {
+    "Pagination": {
+      "DefaultPageSize": 10,
+      "MaxPageSize": 100
+    }
+  }
 }


### PR DESCRIPTION
### BookService
Added a service to handle CRUD operations over Book instances via its repository; a layer to make endpoints as light as possible with top-level method invocations only.

### Edit Endpoint
Added a separate endpoint for editing a book, instead of just making use of the Save endpoint for this purpose as was in the previous iteration



